### PR TITLE
Fix entities being indexed in different formats during rebuild and update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
         pip install -r dev-requirements.txt
         pip install -e .
         
-        pip install -e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
+        pip install -e git+https://github.com/ckan/ckanext-pages.git@b0b2961608a1b2a98151768d9f5e7eebc6274f0a#egg=ckanext-pages
     - name: Setup extension
       # Extra initialization steps
       run: |

--- a/ckanext/sitesearch/logic/chained_action.py
+++ b/ckanext/sitesearch/logic/chained_action.py
@@ -102,7 +102,7 @@ def organization_update(up_func, context, data_dict):
 
     data_dict = up_func(context, data_dict)
 
-    index.index_organization(data_dict)
+    rebuild.rebuild_orgs(entity_id=data_dict['id'])
 
     return data_dict
 
@@ -133,7 +133,7 @@ def group_update(up_func, context, data_dict):
 
     data_dict = up_func(context, data_dict)
 
-    index.index_group(data_dict)
+    rebuild.rebuild_groups(entity_id=data_dict['id'])
 
     return data_dict
 
@@ -163,7 +163,7 @@ def user_update(up_func, context, data_dict):
 
     data_dict = up_func(context, data_dict)
 
-    index.index_user(data_dict)
+    rebuild.rebuild_users(entity_id=data_dict['id'])
 
     return data_dict
 

--- a/ckanext/sitesearch/tests/test_blueprints.py
+++ b/ckanext/sitesearch/tests/test_blueprints.py
@@ -45,11 +45,11 @@ class TestDatasetCreationWorkflow:
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", True)
     def test_dataset_creation_workflow_index_properly(self, app):
 
-        sysadmin = factories.Sysadmin()
+        sysadmin = factories.SysadminWithToken()
         organization = factories.Organization()
 
         url = tk.url_for("dataset.new")
-        extra_environ = {"REMOTE_USER": sysadmin["name"]}
+        extra_environ = {"Authorization": sysadmin["token"]}
         app.post(
             url,
             extra_environ=extra_environ,

--- a/ckanext/sitesearch/tests/test_blueprints.py
+++ b/ckanext/sitesearch/tests/test_blueprints.py
@@ -7,7 +7,7 @@ from ckan.tests import factories, helpers
 
 
 def _get_extra_environ(user):
-    """ Returns an extra_environ dictionary
+    """Returns an extra_environ dictionary
 
     CKAN 2.10 deprecates REMOTE_USER as a valid
     environ variable in favor of an
@@ -23,7 +23,7 @@ def _get_extra_environ(user):
 
 
 def _get_sysadmin():
-    """ Returns a sysadmin user
+    """Returns a sysadmin user
 
     CKAN 2.10 requires an Authorization token to
     call app.post() method and exempt CSRF protection.

--- a/ckanext/sitesearch/tests/test_blueprints.py
+++ b/ckanext/sitesearch/tests/test_blueprints.py
@@ -6,6 +6,35 @@ import ckan.plugins.toolkit as tk
 from ckan.tests import factories, helpers
 
 
+def _get_extra_environ(user):
+    """ Returns an extra_environ dictionary
+
+    CKAN 2.10 deprecates REMOTE_USER as a valid
+    environ variable in favor of an
+    Authorization header. This can be removed when
+    dropping support for CKAN 2.9.
+    """
+    extra_environ = {}
+    try:
+        extra_environ["Authorization"] = user["token"]
+    except KeyError:
+        extra_environ["REMOTE_USER"] = user["name"]
+    return extra_environ
+
+
+def _get_sysadmin():
+    """ Returns a sysadmin user
+
+    CKAN 2.10 requires an Authorization token to
+    call app.post() method and exempt CSRF protection.
+    This can be removed when dropping support for 2.9
+    """
+    try:
+        return factories.SysadminWithToken()
+    except AttributeError:
+        return factories.Sysadmin()
+
+
 class CustomDatasetType(plugins.SingletonPlugin, tk.DefaultDatasetForm):
 
     plugins.implements(plugins.IDatasetForm, inherit=True)
@@ -20,11 +49,10 @@ class TestBlueprint:
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", True)
     def test_search_datasets_returns_only_datasts(self, app):
 
-        sysadmin = factories.Sysadmin()
+        sysadmin = _get_sysadmin()
+
         factories.User()
-
         factories.Group()
-
         factories.Dataset()
         factories.Dataset()
         factories.Dataset(type="custom_dataset")
@@ -33,7 +61,7 @@ class TestBlueprint:
 
         assert "3 datasets found" in response.body
 
-        extra_environ = {"REMOTE_USER": sysadmin["name"]}
+        extra_environ = _get_extra_environ(sysadmin)
 
         response = app.get("/dataset?q=*:*", extra_environ=extra_environ)
 
@@ -45,11 +73,11 @@ class TestDatasetCreationWorkflow:
     @pytest.mark.ckan_config("ckan.auth.create_unowned_dataset", True)
     def test_dataset_creation_workflow_index_properly(self, app):
 
-        sysadmin = factories.SysadminWithToken()
+        sysadmin = _get_sysadmin()
         organization = factories.Organization()
 
         url = tk.url_for("dataset.new")
-        extra_environ = {"Authorization": sysadmin["token"]}
+        extra_environ = _get_extra_environ(sysadmin)
         app.post(
             url,
             extra_environ=extra_environ,


### PR DESCRIPTION
- Updates index unvalidated dicts, which may have a different structure from validted ones, like having extras in a dict instead of their own fields. Unify by always using the rebuild functions.
- Merge from upstream main and pin ckanext-pages revision used in CI to fix tests